### PR TITLE
feat: refactor salt ai UI & state management

### DIFF
--- a/app/(dashboard)/contents-cooker/layout.tsx
+++ b/app/(dashboard)/contents-cooker/layout.tsx
@@ -1,0 +1,18 @@
+import { RightSidebar } from '@/components/RightSidebar'
+
+interface ContentsCookerLayoutProps {
+  children: React.ReactNode
+}
+
+export default function ContentsCookerLayout({
+  children,
+}: ContentsCookerLayoutProps) {
+  return (
+    <div className="flex h-screen">
+      <main className="flex-1 bg-white m-6 rounded-xl overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:'none'] [scrollbar-width:'none']">
+        {children}
+      </main>
+      <RightSidebar />
+    </div>
+  )
+} 

--- a/app/(dashboard)/contents-cooker/post-radar/page.tsx
+++ b/app/(dashboard)/contents-cooker/post-radar/page.tsx
@@ -1,8 +1,10 @@
+import { ContentList } from "@/components/contents-helper/ContentList";
+
 export default function PostRadarPage() {
     return (
         <div className="container mx-auto py-6">
             <h1 className="text-3xl font-bold mb-6">Post Radar</h1>
-            <p>Post Radar page is under construction.</p>
+            <ContentList category="external" title="Post Radar" />
         </div>
     );
 } 

--- a/app/(dashboard)/contents-cooker/saved/page.tsx
+++ b/app/(dashboard)/contents-cooker/saved/page.tsx
@@ -1,8 +1,27 @@
+import { ContentList } from "@/components/contents-helper/ContentList";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
 export default function SavedPage() {
     return (
         <div className="container mx-auto py-6">
             <h1 className="text-3xl font-bold mb-6">Saved</h1>
-            <p>Saved page is under construction.</p>
+
+            <div className="flex flex-col gap-4 mb-6 bg-gray-100 p-4 rounded-lg">
+                {/* threads 콘텐츠 url 입력하면 draft에 추가하기*/}
+                <div className="flex gap-2 items-center">
+                    <div className="text-lg font-bold">Add by URL</div>
+                    <p className="text-sm text-muted-foreground">
+                        Add threads content by url.
+                    </p>
+                </div>
+                <div className="flex gap-2">
+                    <Input id="url" placeholder="https://threads.net/..." />
+                    <Button>Add by URL</Button>
+                </div>
+
+            </div>
+            <ContentList category="saved" title="Saved" />
         </div>
     );
 } 

--- a/app/(dashboard)/contents-cooker/topic-finder/page.tsx
+++ b/app/(dashboard)/contents-cooker/topic-finder/page.tsx
@@ -10,6 +10,8 @@ import { redirect } from 'next/navigation';
 import { getServerSession } from 'next-auth'
 import { createClient } from '@/lib/supabase/server'
 import { authOptions } from '@/lib/auth/authOptions'
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 
 export default async function TopicFinderPage() {
     const session = await getServerSession(authOptions)
@@ -64,6 +66,18 @@ export default async function TopicFinderPage() {
                         <SaltAIGeneratorButton />
                     </div>
                 </div>
+
+
+                {/* Text details input for topic */}
+                <div className="flex flex-col gap-4">
+                    <Input placeholder="Enter topic details" />
+                    {/* Add button */}
+                    <div className="flex justify-end">
+                        <Button>Add</Button>
+                    </div>
+                </div>
+
+
             </div>
         </div>
     );

--- a/app/actions/content.ts
+++ b/app/actions/content.ts
@@ -5,8 +5,8 @@ import { cookies } from 'next/headers'
 import { revalidatePath } from 'next/cache'
 
 export type ContentSource = 'my' | 'external'
-export type ContentCategory = 'all' | 'viral' | 'news' | 'drafts'
-export type PublishStatus = 'draft' | 'scheduled' | 'published' | 'failed'
+export type ContentCategory = 'external' | 'saved'
+export type PublishStatus = 'draft' | 'scheduled' | 'posted'
 
 export type Content = {
   id?: string
@@ -54,7 +54,7 @@ export async function getContents(params?: {
 }) {
   try {
     const supabase = await createClient()
-    const { source = 'my', category = 'all' } = params || {}
+    const { source = 'my', category } = params || {}
 
     let query;
 
@@ -64,14 +64,9 @@ export async function getContents(params?: {
         .from('my_contents')
         .select('*')
 
-      // drafts 카테고리 처리 - draft 상태만 조회
-      if (category === 'drafts') {
+      // saved 카테고리 처리
+      if (category === 'saved') {
         query = query.eq('publish_status', 'draft')
-      }
-      // 그 외 카테고리 처리 - scheduled 또는 posted 상태만 조회
-      else {
-        query = query.in('publish_status', ['scheduled', 'posted'])
-
       }
     }
     // external_contents 테이블에서 조회

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -35,7 +35,7 @@ interface PostCardProps {
   url?: string;
   onAdd?: () => void;
   onMinus?: () => void;
-  onSelect?: (type: "format" | "content") => void;
+  onSelect?: () => void;
   isSelected?: boolean;
   order?: number;
   onContentChange?: (content: string) => void;
@@ -195,7 +195,7 @@ export function PostCard({
 
   return (
     <div
-      className={`space-y-4 w-full h-auto ${isCompact ? "p-3 border rounded-xl" : "p-4 mb-4"
+      className={`space-y-4 w-full h-auto border p-3 rounded-xl ${isCompact ? "" : "p-3 mb-4"
         } ${isSelected ? "bg-accent rounded-xl border-none" : "bg-card"}`}
     >
       <div className="flex gap-3">

--- a/components/RightSidebar.tsx
+++ b/components/RightSidebar.tsx
@@ -39,22 +39,23 @@ export function RightSidebar({ className }: RightSidebarProps) {
   const [selectedMediaType, setSelectedMediaType] = useState<
     "TEXT" | "IMAGE" | "VIDEO" | "CAROUSEL"
   >("TEXT");
+  const { currentSocialId, currentUsername } = useSocialAccountStore();
 
   // selectedPosts가 2개가 되었을 때 첫 번째 포스트의 type을 'format', 두 번째 포스트의 type을 'content'로 설정
   useEffect(() => {
     if (selectedPosts.length === 2) {
       // 첫 번째 포스트에 type이 없으면 'format'으로 설정
       if (!selectedPosts[0].type) {
-        updatePostType(selectedPosts[0].id, "format");
+        updatePostType(selectedPosts[0].id, "topic");
       }
       // 두 번째 포스트에 type이 없으면 'content'로 설정
       if (!selectedPosts[1].type) {
-        updatePostType(selectedPosts[1].id, "content");
+        updatePostType(selectedPosts[1].id, "ingredient");
       }
       // 두 포스트의 type이 같으면, 나중에 추가된 포스트를 다른 type으로 설정
       else if (selectedPosts[0].type === selectedPosts[1].type) {
         const newType =
-          selectedPosts[0].type === "format" ? "content" : "format";
+          selectedPosts[0].type === "topic" ? "ingredient" : "topic";
         updatePostType(selectedPosts[1].id, newType);
       }
     }
@@ -121,14 +122,6 @@ export function RightSidebar({ className }: RightSidebarProps) {
       addPost({
         id: tempId,
         content: writingContent,
-        username: "Username",
-        timestamp: new Date().toISOString(),
-        viewCount: 0,
-        likeCount: 0,
-        commentCount: 0,
-        repostCount: 0,
-        shareCount: 0,
-        avatar: "/avatars/01.png",
       });
       setHasUnsavedContent(false);
       localStorage.removeItem("draftContent");
@@ -250,14 +243,14 @@ export function RightSidebar({ className }: RightSidebarProps) {
   const canComposeWithAI =
     selectedPosts.length === 2 &&
     selectedPosts.every((post) => post.type) &&
-    selectedPosts.some((post) => post.type === "format") &&
-    selectedPosts.some((post) => post.type === "content");
+    selectedPosts.some((post) => post.type === "topic") &&
+    selectedPosts.some((post) => post.type === "ingredient");
 
   const handleComposeWithAI = async () => {
     if (!canComposeWithAI) return;
 
-    const formatPost = selectedPosts.find((post) => post.type === "format");
-    const contentPost = selectedPosts.find((post) => post.type === "content");
+    const formatPost = selectedPosts.find((post) => post.type === "topic");
+    const contentPost = selectedPosts.find((post) => post.type === "ingredient");
 
     if (!formatPost || !contentPost) return;
 
@@ -431,18 +424,11 @@ export function RightSidebar({ className }: RightSidebarProps) {
               <PostCard
                 key={post.id}
                 variant={selectedPosts.length >= 2 ? "compact" : "writing"}
-                avatar={post.avatar}
-                username={post.username}
+                avatar='' // 현재 사용자 계정 프로필 이미지
+                username="Example" // 현재 사용자 계정 이름
                 content={
                   selectedPosts.length >= 2 ? post.content : writingContent
                 }
-                timestamp={post.timestamp}
-                viewCount={post.viewCount}
-                likeCount={post.likeCount}
-                commentCount={post.commentCount}
-                repostCount={post.repostCount}
-                shareCount={post.shareCount}
-                topComment={post.topComment}
                 url={post.url}
                 onSelect={(type) => updatePostType(post.id, type)}
                 onMinus={() => removePost(post.id)}

--- a/components/RightSidebar.tsx
+++ b/components/RightSidebar.tsx
@@ -6,14 +6,15 @@ import { PostCard } from "@/components/PostCard";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import useSelectedPostsStore from "@/stores/useSelectedPostsStore";
-import { Sparkles } from "lucide-react";
+import { Sparkles, TextSearch, Radio, PencilLine, ImageIcon, Video } from "lucide-react";
 import { createContent } from "@/app/actions/content";
 import { toast } from "sonner";
 import { composeWithAI, improvePost } from "@/app/actions/openai";
 import { schedulePost, publishPost } from "@/app/actions/schedule";
 import { ChangePublishTimeDialog } from "./schedule/ChangePublishTimeDialog";
 import useSocialAccountStore from "@/stores/useSocialAccountStore";
-import Image from "next/image";
+import NextImage from 'next/image';
+import Link from 'next/link'
 
 interface RightSidebarProps {
   className?: string;
@@ -22,6 +23,7 @@ interface RightSidebarProps {
 export function RightSidebar({ className }: RightSidebarProps) {
   const [showAiInput, setShowAiInput] = useState(false);
   const [isComposing, setIsComposing] = useState(false);
+  const [activePostId, setActivePostId] = useState<string | null>(null);
   const { selectedPosts, removePost, updatePostType, addPost } =
     useSelectedPostsStore();
   const { selectedAccountId, getSelectedAccount } = useSocialAccountStore();
@@ -41,25 +43,25 @@ export function RightSidebar({ className }: RightSidebarProps) {
   >("TEXT");
   const { currentSocialId, currentUsername } = useSocialAccountStore();
 
-  // selectedPosts가 2개가 되었을 때 첫 번째 포스트의 type을 'format', 두 번째 포스트의 type을 'content'로 설정
-  useEffect(() => {
-    if (selectedPosts.length === 2) {
-      // 첫 번째 포스트에 type이 없으면 'format'으로 설정
-      if (!selectedPosts[0].type) {
-        updatePostType(selectedPosts[0].id, "topic");
-      }
-      // 두 번째 포스트에 type이 없으면 'content'로 설정
-      if (!selectedPosts[1].type) {
-        updatePostType(selectedPosts[1].id, "ingredient");
-      }
-      // 두 포스트의 type이 같으면, 나중에 추가된 포스트를 다른 type으로 설정
-      else if (selectedPosts[0].type === selectedPosts[1].type) {
-        const newType =
-          selectedPosts[0].type === "topic" ? "ingredient" : "topic";
-        updatePostType(selectedPosts[1].id, newType);
-      }
-    }
-  }, [selectedPosts.length, selectedPosts]);
+  // // selectedPosts가 2개가 되었을 때 첫 번째 포스트의 type을 'format', 두 번째 포스트의 type을 'content'로 설정
+  // useEffect(() => {
+  //   if (selectedPosts.length === 2) {
+  //     // 첫 번째 포스트에 type이 없으면 'format'으로 설정
+  //     if (!selectedPosts[0].type) {
+  //       updatePostType(selectedPosts[0].id, "topic");
+  //     }
+  //     // 두 번째 포스트에 type이 없으면 'content'로 설정
+  //     if (!selectedPosts[1].type) {
+  //       updatePostType(selectedPosts[1].id, "ingredient");
+  //     }
+  //     // 두 포스트의 type이 같으면, 나중에 추가된 포스트를 다른 type으로 설정
+  //     else if (selectedPosts[0].type === selectedPosts[1].type) {
+  //       const newType =
+  //         selectedPosts[0].type === "topic" ? "ingredient" : "topic";
+  //       updatePostType(selectedPosts[1].id, newType);
+  //     }
+  //   }
+  // }, [selectedPosts.length, selectedPosts]);
 
   // localStorage에서 임시 저장된 내용 불러오기
   useEffect(() => {
@@ -239,31 +241,42 @@ export function RightSidebar({ className }: RightSidebarProps) {
     return null; // 가능한 시간 없음
   }
 
-  // Compose
-  const canComposeWithAI =
-    selectedPosts.length === 2 &&
-    selectedPosts.every((post) => post.type) &&
-    selectedPosts.some((post) => post.type === "topic") &&
-    selectedPosts.some((post) => post.type === "ingredient");
+  // activePostId가 변경될 때 writingContent 업데이트
+  useEffect(() => {
+    if (activePostId) {
+      const activePost = selectedPosts.find(post => post.id === activePostId);
+      if (activePost) {
+        setWritingContent(activePost.content);
+      }
+    }
+  }, [activePostId, selectedPosts]);
+
+  // writingContent가 변경될 때 active 포스트 업데이트
+  useEffect(() => {
+    if (activePostId && writingContent) {
+      const updatedPosts = selectedPosts.map(post =>
+        post.id === activePostId ? { ...post, content: writingContent } : post
+      );
+      // TODO: 포스트 업데이트 로직 구현
+    }
+  }, [writingContent, activePostId]);
+
+  // canComposeWithAI 로직 수정 (type 제거)
+  const canComposeWithAI = selectedPosts.length === 2;
 
   const handleComposeWithAI = async () => {
     if (!canComposeWithAI) return;
 
-    const formatPost = selectedPosts.find((post) => post.type === "topic");
-    const contentPost = selectedPosts.find((post) => post.type === "ingredient");
-
-    if (!formatPost || !contentPost) return;
-
     try {
       setIsComposing(true);
-      const { content, error } = await composeWithAI(formatPost, contentPost);
+      const { content, error } = await composeWithAI(selectedPosts[0], selectedPosts[1]);
 
       if (error) throw new Error(error);
 
       // 선택된 포스트 초기화
       selectedPosts.forEach((post) => removePost(post.id));
 
-      // 생성된 콘텐츠를 writing PostCard에 저장, useEffect 통해 localStorage에 저장
+      // 생성된 콘텐츠를 writing PostCard에 저장
       setWritingContent(content);
       setHasUnsavedContent(true);
 
@@ -381,6 +394,21 @@ export function RightSidebar({ className }: RightSidebarProps) {
     }
   };
 
+  // activePostId 업데이트 useEffect
+  useEffect(() => {
+    if (selectedPosts.length > 0) {
+      // 새로운 포스트가 추가되면 마지막 포스트를 active로 설정
+      setActivePostId(selectedPosts[selectedPosts.length - 1].id);
+    } else {
+      setActivePostId(null);
+    }
+  }, [selectedPosts.length]);
+
+  // 포스트 클릭 핸들러
+  const handlePostClick = (postId: string) => {
+    setActivePostId(postId);
+  };
+
   // UI
 
   return (
@@ -394,18 +422,18 @@ export function RightSidebar({ className }: RightSidebarProps) {
         {/* Header */}
         <div className="flex items-center justify-between pb-4">
           <div className="flex items-center gap-1">
-            <Image src="/Salt-AI.svg" alt="Salt AI" width={48} height={48} />
+            <NextImage src="/Salt-AI.svg" alt="Salt AI" width={48} height={48} />
             <h1 className="text-2xl font-semibold">Salt AI</h1>
           </div>
           {selectedPosts.length > 0 && (
             <h2 className="text-sm font-medium text-muted-foreground">
-              Selected Posts ({selectedPosts.length}/2)
+              Selected Posts ({selectedPosts.length}/3)
             </h2>
           )}
         </div>
 
         {/* Selected Posts Section */}
-        <div className="space-y-4 mb-4">
+        <div className="space-y-4">
           {/* Empty PostCard when no posts are selected */}
           {selectedPosts.length === 0 ? (
             <PostCard
@@ -421,29 +449,52 @@ export function RightSidebar({ className }: RightSidebarProps) {
           ) : (
             /* Selected Posts */
             selectedPosts.map((post, index) => (
-              <PostCard
+              <div
                 key={post.id}
-                variant={selectedPosts.length >= 2 ? "compact" : "writing"}
-                avatar='' // 현재 사용자 계정 프로필 이미지
-                username="Example" // 현재 사용자 계정 이름
-                content={
-                  selectedPosts.length >= 2 ? post.content : writingContent
-                }
-                url={post.url}
-                onSelect={(type) => updatePostType(post.id, type)}
-                onMinus={() => removePost(post.id)}
-                onAiClick={() => setShowAiInput(!showAiInput)}
-                order={index}
-                onContentChange={
-                  selectedPosts.length >= 2 ? undefined : setWritingContent
-                }
-                images={selectedPosts.length >= 2 ? [] : selectedImages}
-                onImagesChange={
-                  selectedPosts.length >= 2 ? undefined : handleImagesChange
-                }
-              />
+                onClick={() => handlePostClick(post.id)}
+                className="cursor-pointer"
+              >
+                <PostCard
+                  variant={post.id === activePostId ? "writing" : "compact"}
+                  avatar='' // 현재 사용자 계정 프로필 이미지
+                  username="Example" // 현재 사용자 계정 이름
+                  content={post.id === activePostId ? writingContent : post.content}
+                  url={post.url}
+                  onMinus={() => removePost(post.id)}
+                  onAiClick={() => setShowAiInput(!showAiInput)}
+                  order={index}
+                  onContentChange={post.id === activePostId ? setWritingContent : undefined}
+                  images={post.id === activePostId ? selectedImages : []}
+                  onImagesChange={post.id === activePostId ? handleImagesChange : undefined}
+                />
+              </div>
             ))
           )}
+          {/* Divider with Text */}
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-gray-200"></div>
+            </div>
+            <div className="relative flex justify-center">
+              <span className="bg-white px-4 text-sm text-gray-400">Or get from</span>
+            </div>
+          </div>
+
+          {/* Navigation Buttons */}
+          <div className="grid grid-cols-3 gap-2">
+            <Link href="/contents-cooker/topic-finder" className="flex flex-col items-center p-4 bg-gray-100 rounded-xl hover:bg-gray-200 transition-colors">
+              <TextSearch className="w-6 h-6 mb-2 text-muted-foreground" />
+              <span className="text-xs text-muted-foreground">Topic Finder</span>
+            </Link>
+            <Link href="/contents-cooker/post-radar" className="flex flex-col items-center p-4 bg-gray-100 rounded-xl hover:bg-gray-200 transition-colors">
+              <Radio className="w-6 h-6 mb-2 text-muted-foreground" />
+              <span className="text-xs text-muted-foreground">Post Radar</span>
+            </Link>
+            <Link href="/contents-cooker/saved" className="flex flex-col items-center p-4 bg-gray-100 rounded-xl hover:bg-gray-200 transition-colors">
+              <PencilLine className="w-6 h-6 mb-2 text-muted-foreground" />
+              <span className="text-xs text-muted-foreground">Saved</span>
+            </Link>
+          </div>
         </div>
 
 

--- a/components/contents-helper/ContentList.tsx
+++ b/components/contents-helper/ContentList.tsx
@@ -63,25 +63,10 @@ export function ContentList({ category, title }: ContentListProps) {
                   variant="default"
                   username="minsung.dev"
                   content={content.content}
-                  timestamp={formatDate(content.created_at)}
-                  viewCount={content.view_count}
-                  likeCount={content.like_count}
-                  commentCount={content.comment_count}
-                  repostCount={content.repost_count}
-                  shareCount={content.share_count}
-                  topComment={content.top_comment}
                   url={content.url}
                   onAdd={() => addPost({
                     id: content.id,
                     content: content.content,
-                    timestamp: content.created_at,
-                    viewCount: content.view_count,
-                    likeCount: content.like_count,
-                    commentCount: content.comment_count,
-                    repostCount: content.repost_count,
-                    shareCount: content.share_count,
-                    topComment: content.top_comment,
-                    url: content.url
                   })}
                   isSelected={selectedPosts.some(post => post.id === content.id)}
                 />

--- a/components/contents-helper/ContentList.tsx
+++ b/components/contents-helper/ContentList.tsx
@@ -1,10 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { ChevronDown, ChevronUp } from 'lucide-react';
 import { PostCard } from '@/components/PostCard';
 import { ContentCategory, ContentItem, ContentListProps } from './types';
-import { Button } from '@/components/ui/button';
 import useSelectedPostsStore from '@/stores/useSelectedPostsStore';
 import { getContents, ContentSource } from '@/app/actions/content';
 import { toast } from 'sonner';
@@ -20,20 +18,11 @@ export function ContentList({ category, title }: ContentListProps) {
     async function fetchContents() {
       setIsLoading(true);
       try {
-        // 카테고리에 따라 source와 파라미터 설정
-        let source: ContentSource = 'my';
-        let params: Parameters<typeof getContents>[0] = { source };
-
-        switch (category) {
-          case 'viral':
-          case 'news':
-            source = 'external';
-            params = { source, category };
-            break;
-          case 'drafts':
-            params = { source: 'my', category: 'drafts' };
-            break;
-        }
+        // 카테고리에 따라 데이터 조회
+        const params: { source: ContentSource; category: ContentCategory } = {
+          source: category === 'external' ? 'external' : 'my',
+          category
+        };
 
         const { data, error } = await getContents(params);
         if (error) throw error;
@@ -62,9 +51,6 @@ export function ContentList({ category, title }: ContentListProps) {
 
   return (
     <div className="pt-6">
-      {/* 헤더 */}
-      <h2 className="text-2xl font-semibold pb-4">{title}</h2>
-
       {/* 컨텐츠 목록 */}
       {isExpanded && (
         <div className="columns-1 md:columns-2 gap-6 space-y-6">
@@ -88,7 +74,6 @@ export function ContentList({ category, title }: ContentListProps) {
                   onAdd={() => addPost({
                     id: content.id,
                     content: content.content,
-                    username: "minsung.dev",
                     timestamp: content.created_at,
                     viewCount: content.view_count,
                     likeCount: content.like_count,

--- a/components/contents-helper/types.ts
+++ b/components/contents-helper/types.ts
@@ -1,4 +1,4 @@
-export type ContentCategory = 'viral' | 'news' | 'drafts';
+export type ContentCategory = 'external' | 'saved';
 
 export type PublishStatus = 'draft' | 'scheduled' | 'posted';
 
@@ -6,11 +6,11 @@ export interface ContentItem {
   id: string;
   content: string;
   created_at: string;
-  view_count: number;
-  like_count: number;
-  comment_count: number;
-  repost_count: number;
-  share_count: number;
+  view_count?: number;
+  like_count?: number;
+  comment_count?: number;
+  repost_count?: number;
+  share_count?: number;
   top_comment?: string;
   url?: string;
   publish_status?: 'draft' | 'scheduled' | 'published' | 'failed';

--- a/stores/useSelectedPostsStore.ts
+++ b/stores/useSelectedPostsStore.ts
@@ -3,7 +3,6 @@ import { create } from 'zustand'
 interface SelectedPost {
   id: string
   content: string
-  type?: 'topic' | 'ingredient'
   url?: string
 }
 
@@ -11,20 +10,26 @@ interface SelectedPostsState {
   selectedPosts: SelectedPost[]
   addPost: (post: SelectedPost) => void
   removePost: (postId: string) => void
-  updatePostType: (postId: string, type: 'topic' | 'ingredient') => void
+  updatePostType: (postId: string) => void
   clearPosts: () => void
 }
 
 const useSelectedPostsStore = create<SelectedPostsState>((set) => ({
   selectedPosts: [],
 
+  // 포스트 추가
   addPost: (post) => set((state) => {
     // 이미 2개가 선택되어 있으면 추가하지 않음
-    if (state.selectedPosts.length >= 2) return state
+    if (state.selectedPosts.length >= 3) {
+      return { selectedPosts: state.selectedPosts }
+    }
 
     // 이미 선택된 포스트면 추가하지 않음
-    if (state.selectedPosts.some(p => p.id === post.id)) return state
+    if (state.selectedPosts.some(p => p.id === post.id)) {
+      return { selectedPosts: state.selectedPosts }
+    }
 
+    // 조건을 모두 통과한 경우에만 새 포스트 추가
     return { selectedPosts: [...state.selectedPosts, post] }
   }),
 
@@ -32,9 +37,9 @@ const useSelectedPostsStore = create<SelectedPostsState>((set) => ({
     selectedPosts: state.selectedPosts.filter(post => post.id !== postId)
   })),
 
-  updatePostType: (postId, type) => set((state) => ({
+  updatePostType: (postId) => set((state) => ({
     selectedPosts: state.selectedPosts.map(post =>
-      post.id === postId ? { ...post, type } : post
+      post.id === postId ? { ...post, } : post
     )
   })),
 

--- a/stores/useSelectedPostsStore.ts
+++ b/stores/useSelectedPostsStore.ts
@@ -3,16 +3,7 @@ import { create } from 'zustand'
 interface SelectedPost {
   id: string
   content: string
-  username: string
-  avatar?: string
-  type?: 'format' | 'content'
-  timestamp?: string
-  viewCount?: number
-  likeCount?: number
-  commentCount?: number
-  repostCount?: number
-  shareCount?: number
-  topComment?: string
+  type?: 'topic' | 'ingredient'
   url?: string
 }
 
@@ -20,7 +11,7 @@ interface SelectedPostsState {
   selectedPosts: SelectedPost[]
   addPost: (post: SelectedPost) => void
   removePost: (postId: string) => void
-  updatePostType: (postId: string, type: 'format' | 'content') => void
+  updatePostType: (postId: string, type: 'topic' | 'ingredient') => void
   clearPosts: () => void
 }
 


### PR DESCRIPTION
### RightSidebar.tsx(Salt AI) UI 개편
- 콘텐츠 3개까지 추가
- Topic Finder / Post Radar / Saved에서 각각 추가할 수 있도록 버튼 추가
- 추가된 Post 클릭하면 writing 가능한 상태로 바뀌며 다른 Post들은 compact 상태로 바뀜

### Salt ai UI & state management
- format / content 구분 삭제 (한 콘텐츠 내 format과 content 구분의 모호함 존재)
- content끼리 조합하여 더 풍성한 콘텐츠를 만드는 방향으로 변경